### PR TITLE
added xvfb for running selenium tests headless

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -48,6 +48,8 @@ tasks:
           whereis browsers &&
           echo "install FF" &&
           apt-get update &&
+          apt-get install xvfb -y &&
+          Xvfb :99 -ac &; export DISPLAY=:99 &&
           echo "whereis firefox part II" &&
           whereis firefox &&
           node runTest.js &&


### PR DESCRIPTION
Xvfb is required if running selenium tests headless inside a docker container.